### PR TITLE
HitDeterminator now recognizes different user moves

### DIFF
--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -11,8 +11,8 @@ module Api
       end
 
       def hits_array
-        current_user_game = UserGame.find_by(id: params[:user_game_id])
-        data = HitDeterminator.determine(params[:coords], current_user_game)
+        player_user_game = UserGame.find_by(id: params[:user_game_id])
+        data = HitDeterminator.determine_turn_outcome(params[:player_coords], params[:ai_coords], player_user_game)
         render json: { data: data }
       end
     end

--- a/app/controllers/api/v1/user_games_controller.rb
+++ b/app/controllers/api/v1/user_games_controller.rb
@@ -7,12 +7,14 @@ module Api
       end
 
       def show
+
         render json: UserGame.includes(:user, :game, :ships).find_by(id: params[:id]), include: ['ships']
       end
 
-      def hits_array #expect from AJAX: user_game, coordinates
+      def hits_array
         current_user_game = UserGame.find_by(id: params[:id])
-        data = HitDeterminator.determine(params[:coords], current_user_game)
+        # data = HitDeterminator.determine_turn_outcome(params[:player_coords], current_user_game)
+        data = HitDeterminator.determine_turn_outcome(params[:player_coords], params[:ai_coords], current_user_game)
         render json: { data: data }
       end
     end

--- a/app/services/hit_determinator.rb
+++ b/app/services/hit_determinator.rb
@@ -1,24 +1,55 @@
 class HitDeterminator
-  def self.determine(coords, current_user_game)
-    opponent_user_game = current_user_game.other_user_game
-    hit = opponent_user_game.ships.map(&:coordinates).map{|coord| coord.split(",")}.flatten.include?(coords)
-    x, y = coords[0].to_i, coords[1].to_i
-    if (opponent_user_game.hits[x][y] == 1) || (opponent_user_game.hits[x][y] == 2)
-      message = 0
-    elsif hit
-      message = 2
-      opponent_user_game.hits[x][y] = 2
-    else 
-      message = 1
-      opponent_user_game.hits[x][y] = 1
-    end
-    opponent_user_game.save
+  # def self.determine_turn_outcome(player_coords, player_user_game)
+  def self.determine_turn_outcome(player_coords, ai_coords, player_user_game)
+    opponent_user_game = player_user_game.other_user_game
 
-    hits_string = opponent_user_game.hits.flatten.inject(""){|l,z| "#{l},#{z}"}[1..-1]
+    # hit = opponent_user_game.ships.map(&:coordinates).map{|coord| coord.split(",")}.flatten.include?(player_coords)
+    # x, y = player_coords[0].to_i, player_coords[1].to_i
+    # if (opponent_user_game.hits[x][y] == 1) || (opponent_user_game.hits[x][y] == 2)
+    #   # message = 0
+    # elsif hit
+    #   # message = 2
+    #   opponent_user_game.hits[x][y] = 2
+    # else 
+    #   # message = 1
+    #   opponent_user_game.hits[x][y] = 1
+    # end
+    # opponent_user_game.save
+
+    ai_board_hits_string = update_user_game_hits(opponent_user_game, player_coords)
+    player_board_hits_string = update_user_game_hits(player_user_game, ai_coords)
 
     data = {
-      message: message,
-      grid: hits_string
+      # message: message,
+      ai_grid: ai_board_hits_string,
+      player_grid: player_board_hits_string
     }
   end
+
+  private
+
+  def self.update_user_game_hits(user_game, coords)
+    hit = user_game.ships.map(&:coordinates).map{|coord| coord.split(",")}.flatten.include?(coords)
+    x, y = coords[0].to_i, coords[1].to_i
+    if (user_game.hits[x][y] == 1) || (user_game.hits[x][y] == 2)
+      # logic if we want to let user know they already hit that target
+    elsif hit
+      user_game.hits[x][y] = 2
+      determine_sunk_ship(user_game)
+    else 
+      user_game.hits[x][y] = 1
+    end
+    user_game.save
+    user_game.hits.flatten.inject(""){|l,z| "#{l},#{z}"}[1..-1]
+  end
+
+  def self.determine_sunk_ship(user_game)
+    user_game.ships.each do |ship|
+      ship_sunk = ship.coordinates.split(",").all? { |coord| user_game.hits[coord[0].to_i][coord[1].to_i] == "2" }
+      if ship_sunk
+        ship.coordinates.split(",").each { |coord| user_game.hits[coord[0].to_i][coord[1].to_i] = "3" }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
HitDeterminator now is able to receive and process moves for two different players, presumably player1 and the AI
Working currently on making it determine whether a ship has been sunk.
